### PR TITLE
Add support for subcommands

### DIFF
--- a/cli/internal/base/base.go
+++ b/cli/internal/base/base.go
@@ -13,22 +13,47 @@ type Command struct {
 	Short     string
 	Long      string
 	Flag      flag.FlagSet
+	Commands  []*Command
 }
 
-var Commands []*Command
+var CLI = &Command{
+	UsageLine: "cli",
+	Long:      "CLI is a minimal CLI application with commands",
+}
+
+func (c *Command) Lookup(name string) *Command {
+	for _, sub := range c.Commands {
+		if sub.Name() == name {
+			return sub
+		}
+	}
+	return nil
+}
+
+// LongName returns the command's long name: all the words in the usage line
+// between "cli" and a flag or argument.
+func (c *Command) LongName() string {
+	name := c.UsageLine
+	if i := strings.Index(name, " ["); i >= 0 {
+		name = name[:i]
+	}
+	if name == "cli" {
+		return ""
+	}
+	return strings.TrimPrefix(name, "cli ")
+}
 
 func (c *Command) Name() string {
-	name := c.UsageLine
-	i := strings.Index(name, " ")
-	if i >= 0 {
-		name = name[:i]
+	name := c.LongName()
+	if i := strings.LastIndex(name, " "); i >= 0 {
+		name = name[i+1:]
 	}
 	return name
 }
 
 func (c *Command) Usage() {
 	fmt.Fprintf(os.Stderr, "usage: %s\n", c.UsageLine)
-	fmt.Fprintf(os.Stderr, "Run 'cli help %s' for details.\n", c.Name())
+	fmt.Fprintf(os.Stderr, "Run 'cli help %s' for details.\n", c.LongName())
 	os.Exit(2)
 }
 

--- a/cli/internal/base/base.go
+++ b/cli/internal/base/base.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Command struct {
-	Run       func(cmd *Command, args []string)
+	Run       func(cmd *Command, args []string) error
 	UsageLine string
 	Short     string
 	Long      string

--- a/cli/internal/one/one.go
+++ b/cli/internal/one/one.go
@@ -23,6 +23,7 @@ func init() {
 	CmdOne.Flag.BoolVar(&exampleFlag, "f", false, "Example flag")
 }
 
-func runOne(cmd *base.Command, args []string) {
+func runOne(cmd *base.Command, args []string) error {
 	fmt.Printf("one! exampleFlag=%v\n", exampleFlag)
+	return nil
 }

--- a/cli/internal/one/one.go
+++ b/cli/internal/one/one.go
@@ -7,7 +7,7 @@ import (
 )
 
 var CmdOne = &base.Command{
-	UsageLine: "one [-f]",
+	UsageLine: "cli one [-f]",
 	Short:     "short description for one",
 	Long: `
 Long description for one.

--- a/cli/internal/three/a.go
+++ b/cli/internal/three/a.go
@@ -1,0 +1,29 @@
+package three
+
+import (
+	"fmt"
+
+	"github.com/jroimartin/template/cli/internal/base"
+)
+
+var cmdA = &base.Command{
+	UsageLine: "cli three a [-f]",
+	Short:     "short description for a",
+	Long: `
+Long description for three a.
+
+It supports multiple lines.
+	`,
+}
+
+var exampleFlag bool
+
+func init() {
+	cmdA.Run = runA
+	cmdA.Flag.BoolVar(&exampleFlag, "f", false, "Example flag")
+}
+
+func runA(cmd *base.Command, args []string) error {
+	fmt.Printf("three a! exampleFlag=%v\n", exampleFlag)
+	return nil
+}

--- a/cli/internal/three/b.go
+++ b/cli/internal/three/b.go
@@ -1,0 +1,27 @@
+package three
+
+import (
+	"fmt"
+
+	"github.com/jroimartin/template/cli/internal/base"
+)
+
+var cmdB = &base.Command{
+	UsageLine: "cli three b [-f]",
+	Short:     "short description for b",
+	Long: `
+Long description for three b.
+
+It supports multiple lines.
+	`,
+}
+
+func init() {
+	cmdB.Run = runB
+	cmdB.Flag.BoolVar(&exampleFlag, "f", false, "Example flag")
+}
+
+func runB(cmd *base.Command, args []string) error {
+	fmt.Printf("three b! exampleFlag=%v\n", exampleFlag)
+	return nil
+}

--- a/cli/internal/three/three.go
+++ b/cli/internal/three/three.go
@@ -1,0 +1,20 @@
+package three
+
+import (
+	"github.com/jroimartin/template/cli/internal/base"
+)
+
+var CmdThree = &base.Command{
+	UsageLine: "cli three",
+	Short:     "three has subcommands",
+	Long: `
+Long description for three.
+
+It supports multiple lines.
+	`,
+
+	Commands: []*base.Command{
+		cmdA,
+		cmdB,
+	},
+}

--- a/cli/internal/two/two.go
+++ b/cli/internal/two/two.go
@@ -23,6 +23,7 @@ func init() {
 	CmdTwo.Flag.BoolVar(&exampleFlag, "f", false, "Example flag")
 }
 
-func runTwo(cmd *base.Command, args []string) {
+func runTwo(cmd *base.Command, args []string) error {
 	fmt.Printf("two! exampleFlag=%v\n", exampleFlag)
+	return nil
 }

--- a/cli/internal/two/two.go
+++ b/cli/internal/two/two.go
@@ -7,7 +7,7 @@ import (
 )
 
 var CmdTwo = &base.Command{
-	UsageLine: "two [-f]",
+	UsageLine: "cli two [-f]",
 	Short:     "short description for two",
 	Long: `
 Long description for two.

--- a/cli/main.go
+++ b/cli/main.go
@@ -43,7 +43,10 @@ func main() {
 		if cmd.Name() == args[0] {
 			cmd.Flag.Parse(args[1:])
 			args = cmd.Flag.Args()
-			cmd.Run(cmd, args)
+			if err := cmd.Run(cmd, args); err != nil {
+				fmt.Fprintf(os.Stderr, "error: %v\n", err)
+				os.Exit(1)
+			}
 			return
 		}
 	}

--- a/cli/main.go
+++ b/cli/main.go
@@ -6,17 +6,20 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/jroimartin/template/cli/internal/base"
 	"github.com/jroimartin/template/cli/internal/help"
 	"github.com/jroimartin/template/cli/internal/one"
+	"github.com/jroimartin/template/cli/internal/three"
 	"github.com/jroimartin/template/cli/internal/two"
 )
 
 func init() {
-	base.Commands = []*base.Command{
+	base.CLI.Commands = []*base.Command{
 		one.CmdOne,
 		two.CmdTwo,
+		three.CmdThree,
 	}
 
 	base.Usage = mainUsage
@@ -38,24 +41,54 @@ func main() {
 		return
 	}
 
-	for _, cmd := range base.Commands {
-		cmd.Flag.Usage = cmd.Usage
-		if cmd.Name() == args[0] {
-			cmd.Flag.Parse(args[1:])
-			args = cmd.Flag.Args()
-			if err := cmd.Run(cmd, args); err != nil {
-				fmt.Fprintf(os.Stderr, "error: %v\n", err)
-				os.Exit(1)
-			}
-			return
+	cmd, used := lookupCmd(args)
+	if len(cmd.Commands) == 0 {
+		invoke(cmd, args[used-1:])
+	} else {
+		if used >= len(args) {
+			//Subcommand is missing.
+			help.PrintUsage(cmd)
+			os.Exit(2)
 		}
-	}
 
-	fmt.Fprintf(os.Stderr, "cli: unknown subcommand %q\nRun 'cli help' for usage.\n", args[0])
-	os.Exit(2)
+		// Command or subcommand are unknown.
+		helpArg := ""
+		if used > 0 {
+			// Subcommand is unknown.
+			helpArg += " " + strings.Join(args[:used], " ")
+		}
+
+		fmt.Fprintf(os.Stderr, "cli %s: unknown command\nRun 'cli help%s' for usage.\n", args[0], helpArg)
+		os.Exit(2)
+	}
+}
+
+func lookupCmd(args []string) (cmd *base.Command, used int) {
+	cmd = base.CLI
+	for used < len(args) {
+		c := cmd.Lookup(args[used])
+		if c == nil {
+			// Command not found. If len(cmd.Commands) == 0 it may be an
+			// argument for the current command.
+			break
+		}
+		cmd = c
+		used++
+	}
+	return cmd, used
+}
+
+func invoke(cmd *base.Command, args []string) {
+	cmd.Flag.Usage = func() { cmd.Usage() }
+	cmd.Flag.Parse(args[1:])
+	args = cmd.Flag.Args()
+	if err := cmd.Run(cmd, args); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
 }
 
 func mainUsage() {
-	help.PrintUsage()
+	help.PrintUsage(base.CLI)
 	os.Exit(2)
 }


### PR DESCRIPTION
This PR adds support for subcommands inspired in the way implemented by the Go tool, in commands like `go mod`. It also adds an example of a command (`three`) with subcommands (`a` and `b`).

Usage examples:
```
$ cli
CLI is a minimal CLI application with commands

Usage:

	cli <command> [arguments]

The commands are:

	one         short description for one
	two         short description for two
	three       three has subcommands

Use "cli help <command>" for more information about a command.
```
```
$ cli one
one! exampleFlag=false
```
```
$ cli help one
usage: cli one [-f]

Long description for one.

It supports multiple lines.
```
```
$ cli three
Long description for three.

It supports multiple lines.

Usage:

	cli three <command> [arguments]

The commands are:

	a           short description for a
	b           short description for b

Use "cli help three <command>" for more information about a command.
```
```
$ cli help three a
usage: cli three a [-f]

Long description for three a.

It supports multiple lines.
```
```
$ cli three a
three a! exampleFlag=false
```
```
$ cli a
cli a: unknown command
Run 'cli help' for usage.
```
```
$ cli three c
cli three: unknown command
Run 'cli help three' for usage.
```
```
$ cli three help a
cli three: unknown command
Run 'cli help three' for usage.
```